### PR TITLE
Use wp as ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,5 @@ RUN set -ex \
   && rm wp.sha512
 
 WORKDIR /var/www/html
+
+ENTRYPOINT [ "/usr/local/bin/wp" ]


### PR DESCRIPTION
This PR explicitly sets `wp` as the entrypoint for the wordpress-cli image, enabling use of both `wp`'s core and plugin-provided commands without needing to double-specify `wp` with the `f1` command.